### PR TITLE
Create one bucket for many VPCs

### DIFF
--- a/cloud_AWS/ansible/role/handlers/main.yml
+++ b/cloud_AWS/ansible/role/handlers/main.yml
@@ -1,22 +1,16 @@
 ---
-  - name: Create S3 Buckets empty list
-    set_fact:
-      bucket_name_list: "[]"
-    listen: finished_aws
-
   - name: Save S3 Buckets
     set_fact:
-      bucket_name_list: "{{ bucket_name_list }} + [ '{{ item.stack_resources.0.physical_resource_id }}' ]"
+      bucket_name_list: "{{ kentik_bucket.stack_resources.0.physical_resource_id }}"
     listen: finished_aws
-    with_items: "{{ kentik_buckets.results }}"
     when: not s3_flowlogs_bucket
     loop_control:
-      label: "{{ item.stack_resources.0.physical_resource_id if not s3_flowlogs_bucket else s3_flowlogs_bucket }}"
+      label: "{{ kentik_bucket.stack_resources.0.physical_resource_id if not s3_flowlogs_bucket else s3_flowlogs_bucket }}"
 
   - name: Inform of Results
     listen: finished_aws
     debug:
       msg: [
-        "S3 Buckets ARNs: {{ bucket_name_list if not s3_flowlogs_bucket else s3_flowlogs_bucket }}",
+        "S3 Buckets Name: {{ bucket_name_list if not s3_flowlogs_bucket else s3_flowlogs_bucket }}",
         "IAM Role ARN: {{ kentik_role.arn }}"
       ]

--- a/cloud_AWS/ansible/role/tasks/ec2.yml
+++ b/cloud_AWS/ansible/role/tasks/ec2.yml
@@ -7,6 +7,6 @@
         ResourceId: "{{ item }}"
         MaxAggregationInterval: "{{ '60' if store_logs_more_frequently else '600' }}"
       on_create_failure: "DELETE"
-      state: 'present'
+      state: present
     notify: finished_aws
     with_items: "{{ vpc_id_list | mandatory }}"

--- a/cloud_AWS/ansible/role/tasks/s3.yml
+++ b/cloud_AWS/ansible/role/tasks/s3.yml
@@ -1,12 +1,11 @@
 ---
   - name: Create S3 Bucket for VPCs
     cloudformation:
-      stack_name: "{{ '-'.join((s3_bucket_prefix, item, 'flow-logs')) }}"
+      stack_name: "{{ s3_bucket_prefix }}-{{ vpc_id_list[0].split('-')[1] }}-flow-logs"
       template_body: "{{ lookup ('file', 'aws_s3_public_access.json') |string }}"
       template_parameters:
-        BucketName: "{{ [s3_bucket_prefix, item, 'flow-logs'] | join('-') }}"
+        BucketName: "{{ s3_bucket_prefix }}-{{ vpc_id_list[0].split('-')[1] }}-flow-logs"
       on_create_failure: "DELETE"
       state: 'present'
-    register: kentik_buckets
+    register: kentik_bucket
     when: not s3_flowlogs_bucket
-    with_items: "{{ vpc_id_list | mandatory }}"

--- a/cloud_AWS/ansible/role/templates/aws_iam_s3_access_policy.j2
+++ b/cloud_AWS/ansible/role/templates/aws_iam_s3_access_policy.j2
@@ -12,9 +12,7 @@
 {% if s3_flowlogs_bucket %}
         "arn:aws:s3:::{{ s3_flowlogs_bucket }}"
 {% else %}
-{% for v in vpc_id_list %}
-        "arn:aws:s3:::{{ s3_bucket_prefix }}-{{ v }}-flow-logs"{{ ',' if not loop.last else '' }}
-{% endfor %}
+        "arn:aws:s3:::{{ s3_bucket_prefix }}-{{ vpc_id_list[0].split('-')[1] }}-flow-logs"
 {% endif %}
       ]
     },
@@ -33,9 +31,7 @@
 {% if s3_flowlogs_bucket %}
         "arn:aws:s3:::{{ s3_flowlogs_bucket }}/*"
 {% else %}
-{% for v in vpc_id_list %}
-        "arn:aws:s3:::{{ s3_bucket_prefix }}-{{ v }}-flow-logs/*"{{ ',' if not loop.last else '' }}
-{% endfor %}
+        "arn:aws:s3:::{{ s3_bucket_prefix }}-{{ vpc_id_list[0].split('-')[1] }}-flow-logs/*"
 {% endif %}
       ]
     }

--- a/cloud_AWS/ansible/role/templates/aws_vpc_flow_logs.j2
+++ b/cloud_AWS/ansible/role/templates/aws_vpc_flow_logs.j2
@@ -18,7 +18,7 @@
 {% if s3_flowlogs_bucket %}
                 "LogDestination": "arn:aws:s3:::{{ s3_flowlogs_bucket }}/{{ s3_flowlogs_path + '/' if s3_flowlogs_path else '' }}{{ item }}",
 {% else %}
-                "LogDestination": "arn:aws:s3:::{{ s3_bucket_prefix }}-{{ item }}-flow-logs/{{ s3_flowlogs_path + '/' if s3_flowlogs_path else '' }}",
+                "LogDestination": "arn:aws:s3:::{{ s3_bucket_prefix }}-{{ vpc_id_list[0].split('-')[1] }}-flow-logs/{{ s3_flowlogs_path + '/' if s3_flowlogs_path else '' }}{{ item }}",
 {% endif %}
                 "LogDestinationType": "s3",
                 "LogFormat": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",


### PR DESCRIPTION
For all the VPCs listed under the `vpc_id_list` the role will create a single bucket and configure Flow Logs to put logs into `<vpc_id>` directory on this bucket. This way each VPC will have its own space, separated from other VPCs.