### PR TITLE
Updating Kentik clouldexport provider version

### DIFF
--- a/cloud_AWS/terraform/module/cloudexport.tf
+++ b/cloud_AWS/terraform/module/cloudexport.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kentik-cloudexport = {
       source = "kentik/kentik-cloudexport"
-      version = "0.1.0"
+      version = ">= 0.2.0"
     }
   }
 }

--- a/cloud_AWS/terraform/module/demo/main.tf
+++ b/cloud_AWS/terraform/module/demo/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 2.28.1"
     }
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source  = "kentik/kentik-cloudexport"
     }
   }

--- a/cloud_AWS/terraform/module/examples/all-vpc-from-region/main.tf
+++ b/cloud_AWS/terraform/module/examples/all-vpc-from-region/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 2.28.1"
     }
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source = "kentik/kentik-cloudexport"
     }
   }

--- a/cloud_AWS/terraform/module/examples/single-vpc/main.tf
+++ b/cloud_AWS/terraform/module/examples/single-vpc/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 2.28.1"
     }
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source = "kentik/kentik-cloudexport"
     }
   }

--- a/cloud_AWS/terraform/module/tests/main.tf
+++ b/cloud_AWS/terraform/module/tests/main.tf
@@ -6,7 +6,7 @@ terraform {
       version = ">= 2.28.1"
     }
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source  = "kentik/kentik-cloudexport"
     }
   }

--- a/cloud_GCP/terraform/module/cloudexport.tf
+++ b/cloud_GCP/terraform/module/cloudexport.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kentik-cloudexport = {
       source = "kentik/kentik-cloudexport"
-      version = "0.1.0"
+      version = ">= 0.2.0"
     }
   }
 }

--- a/cloud_GCP/terraform/module/examples/all-network-subnets/main.tf
+++ b/cloud_GCP/terraform/module/examples/all-network-subnets/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 3.41.0"
     }
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source = "kentik/kentik-cloudexport"
     }
   }

--- a/cloud_GCP/terraform/module/examples/subnet-list/main.tf
+++ b/cloud_GCP/terraform/module/examples/subnet-list/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 3.41.0"
     }
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source = "kentik/kentik-cloudexport"
     }
   }

--- a/cloud_GCP/terraform/module/tests/main.tf
+++ b/cloud_GCP/terraform/module/tests/main.tf
@@ -6,7 +6,7 @@ terraform {
       version = ">= 3.41.0"
     }
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source = "kentik/kentik-cloudexport"
     }
   }


### PR DESCRIPTION
Setting required version of `kentik-cloudexport` provider to equal to or greater than `0.2.0` (which current latest release).