### PR TITLE
Script to automate creation of terraform resources on multiple AWS accounts

### DIFF
--- a/cloud_AWS/terraform/module/cloudexport.tf
+++ b/cloud_AWS/terraform/module/cloudexport.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 resource "kentik-cloudexport_item" "aws_export" {
-  name           = var.name
+  name           = "${var.name}_${terraform.workspace}"
   type           = "CLOUD_EXPORT_TYPE_KENTIK_MANAGED"
   enabled        = var.enabled
   description    = var.description

--- a/cloud_AWS/terraform/module/examples/multiple_aws_accounts_single_vpc_setup/configure_aws_accounts.py
+++ b/cloud_AWS/terraform/module/examples/multiple_aws_accounts_single_vpc_setup/configure_aws_accounts.py
@@ -1,0 +1,96 @@
+import os
+from pathlib import Path
+import re
+from python_terraform import *
+
+
+def set_env():
+    KTAPI_AUTH_EMAIL_VAL = ""  # input your email
+    KTAPI_AUTH_TOKEN_VAL = ""  # input your token
+
+    os.environ["KTAPI_AUTH_EMAIL"] = KTAPI_AUTH_EMAIL_VAL
+    os.environ["KTAPI_AUTH_TOKEN"] = KTAPI_AUTH_TOKEN_VAL
+
+
+def read_credentials():
+    workspace_regex = "\[(.*)\]"
+    aws_access_key_id_regex = "(aws_access_key_id = )(.*)"
+    aws_secret_access_key_regex = "(aws_secret_access_key = )(.*)"
+
+    credentials_file = str(Path.home()) + "/.aws/credentials"
+    credentials = []
+    with open(credentials_file) as file:
+        workspace = ""
+        aws_access_key = ""
+        aws_secret_access_key = ""
+        for line in file.readlines():
+            results = re.findall(workspace_regex, line)
+
+            if len(results) != 0:
+                workspace = results[0]
+                continue
+            else:
+                results = re.findall(aws_access_key_id_regex, line)
+
+            if len(results) != 0:
+                aws_access_key = results[0][1]
+                continue
+            else:
+                results = re.findall(aws_secret_access_key_regex, line)
+
+            if len(results) != 0:
+                aws_secret_access_key = results[0][1]
+            else:
+                continue
+
+            if workspace != "" and aws_access_key != "" and aws_secret_access_key != "":
+                credentials.append({"workspace": workspace,
+                                    "aws_access_key": aws_access_key,
+                                    "aws_secret_access_key": aws_secret_access_key})
+                workspace = aws_access_key = aws_secret_access_key = ""
+
+    return credentials
+
+
+def apply_terraform_configuration():
+    set_env()
+    t = Terraform()
+    for credentials_set in read_credentials():
+        os.environ["AWS_ACCESS_KEY_ID"] = credentials_set["aws_access_key"]
+        os.environ["AWS_SECRET_ACCESS_KEY"] = credentials_set["aws_secret_access_key"]
+
+        return_code, stdout, stderr = t.create_workspace(credentials_set["workspace"])
+        print(return_code, stdout, stderr)
+
+        if f'Workspace "{credentials_set["workspace"]}" already exists' in stderr:
+            return_code, stdout, stderr = t.set_workspace(credentials_set["workspace"])
+            print(return_code, stdout, stderr)
+
+        t.plan()
+        return_code, stdout, stderr = t.apply(var={'vpc_id': "vpc-0eeb173de06765d0a"}, skip_plan=True)
+        print(return_code, stdout, stderr)
+
+
+def destroy_terraform_configuration():
+    set_env()
+    t = Terraform()
+    for credentials_set in read_credentials():
+        os.environ["AWS_ACCESS_KEY_ID"] = credentials_set["aws_access_key"]
+        os.environ["AWS_SECRET_ACCESS_KEY"] = credentials_set["aws_secret_access_key"]
+
+        return_code, stdout, stderr = t.create_workspace(credentials_set["workspace"])
+        print(return_code, stdout, stderr)
+
+        if f'Workspace "{credentials_set["workspace"]}" already exists' in stderr:
+            return_code, stdout, stderr = t.set_workspace(credentials_set["workspace"])
+            print(return_code, stdout, stderr)
+
+        t.plan()
+
+        vpc_id = ""  # input vpc_id
+        return_code, stdout, stderr = t.apply(destroy=IsFlagged, var={'vpc_id': vpc_id}, skip_plan=True)
+        print(return_code, stdout, stderr)
+
+
+# apply_terraform_configuration()
+# destroy_terraform_configuration()

--- a/cloud_AWS/terraform/module/examples/multiple_aws_accounts_single_vpc_setup/main.tf
+++ b/cloud_AWS/terraform/module/examples/multiple_aws_accounts_single_vpc_setup/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_version = ">= 0.12.0"
+  required_providers {
+    aws = {
+      version = ">= 2.28.1"
+    }
+    kentik-cloudexport = {
+      version = ">= 0.2.0"
+      source  = "kentik/kentik-cloudexport"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-2"
+}
+
+provider "kentik-cloudexport" {}
+
+module "kentik_aws_integration" {
+  // Use the module from local filesystem
+  source = "../../"
+  // Use the module from Github
+  // source = "github.com/kentik/config-snippets-cloud/cloud_AWS/terraform/module"
+
+  rw_s3_access               = true
+  vpc_id_list                = [var.vpc_id]
+  s3_bucket_prefix           = "terraform-example"
+  iam_role_prefix            = "terraform-example"
+  store_logs_more_frequently = true
+  name                       = "example-aws-terraform-name"
+  plan_id                    = "11467"
+  region                     = "us-east-2"
+  // The company ID passed here can be obtained in automated configuration of AWS cloudexport
+  // (https://portal.kentik.com/v4/setup/clouds/aws).
+  external_id                = "74333"
+}

--- a/cloud_AWS/terraform/module/examples/multiple_aws_accounts_single_vpc_setup/output.tf
+++ b/cloud_AWS/terraform/module/examples/multiple_aws_accounts_single_vpc_setup/output.tf
@@ -1,0 +1,7 @@
+output "kentik_iam_role_arn" {
+  value = module.kentik_aws_integration.iam_role_arn
+}
+
+output "kentik_bucket_name" {
+  value = module.kentik_aws_integration.bucket_name_list
+}

--- a/cloud_AWS/terraform/module/examples/multiple_aws_accounts_single_vpc_setup/variables.tf
+++ b/cloud_AWS/terraform/module/examples/multiple_aws_accounts_single_vpc_setup/variables.tf
@@ -1,0 +1,4 @@
+variable "vpc_id" {
+  description = "ID of VPC to configure"
+  type        = string
+}

--- a/cloud_AWS/terraform/module/iam.tf
+++ b/cloud_AWS/terraform/module/iam.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role" "kentik_role" {
   count                 = var.create_role ? 1 : 0
-  name                  = "${var.iam_role_prefix}TerraformIngestRole"
+  name                  = "${var.iam_role_prefix}TerraformIngestRole_${terraform.workspace}"
+
   description           = "This role allows Kentik to ingest the VPC flow logs."
   force_detach_policies = true
   tags = {
@@ -15,7 +16,7 @@ resource "aws_iam_role" "kentik_role" {
 
 resource "aws_iam_policy" "kentik_ec2_access" {
   count       = var.create_role ? 1 : 0
-  name        = "${var.iam_role_prefix}EC2Access"
+  name        = "${var.iam_role_prefix}EC2Access_${terraform.workspace}"
   description = "Defines required accesses for Kentik platform to EC2 resources"
   path        = "/"
   policy      = file("${path.module}/files/kentikEC2Access.json")
@@ -23,7 +24,7 @@ resource "aws_iam_policy" "kentik_ec2_access" {
 
 resource "aws_iam_policy" "kentik_s3_policy" {
   count       = var.create_role ? 1 : 0
-  name        = "${var.iam_role_prefix}S3PolicyAccess"
+  name        = "${var.iam_role_prefix}S3PolicyAccess_${terraform.workspace}"
   description = "Defines accesses for Kentik platform to S3 resources"
   path        = "/"
   policy = templatefile(
@@ -38,14 +39,14 @@ resource "aws_iam_policy" "kentik_s3_policy" {
 
 resource "aws_iam_policy_attachment" "kentik_s3_access" {
   count      = var.create_role ? 1 : 0
-  name       = "${var.iam_role_prefix}-s3-access"
+  name       = "${var.iam_role_prefix}-s3-access_${terraform.workspace}"
   roles      = [aws_iam_role.kentik_role[count.index].name]
   policy_arn = aws_iam_policy.kentik_s3_policy[count.index].arn
 }
 
 resource "aws_iam_policy_attachment" "kentik_ec2_access" {
   count      = var.create_role ? 1 : 0
-  name       = "${var.iam_role_prefix}-ec2-access"
+  name       = "${var.iam_role_prefix}-ec2-access_${terraform.workspace}"
   roles      = [aws_iam_role.kentik_role[count.index].name]
   policy_arn = aws_iam_policy.kentik_ec2_access[count.index].arn
 }

--- a/cloud_AWS/terraform/module/s3.tf
+++ b/cloud_AWS/terraform/module/s3.tf
@@ -1,10 +1,10 @@
 resource "aws_s3_bucket" "vpc_logs" {
   count  = (var.s3_use_one_bucket == false ? length(var.vpc_id_list) : 1)
-  bucket = join("-", [var.s3_bucket_prefix, (var.s3_use_one_bucket == false ? var.vpc_id_list[count.index] : var.s3_base_name), "flow-logs"])
+  bucket = join("-", [var.s3_bucket_prefix, (var.s3_use_one_bucket == false ? var.vpc_id_list[count.index] : var.s3_base_name), "flow-logs", terraform.workspace])
   acl    = "private"
   policy = templatefile(
     "${path.module}/templates/flowLogsS3Policy.json.tmpl",
-    { bucket = join("-", [var.s3_bucket_prefix, (var.s3_use_one_bucket == false ? var.vpc_id_list[count.index] : var.s3_base_name), "flow-logs"])
+    { bucket = join("-", [var.s3_bucket_prefix, (var.s3_use_one_bucket == false ? var.vpc_id_list[count.index] : var.s3_base_name), "flow-logs", terraform.workspace])
   })
 }
 


### PR DESCRIPTION
Terraform module changed in order to allow working with multiple AWS users within single account (resource names are distinct per workspace)

TODO:
- add README