### PR TITLE
Temporary fix to new Terraform AWS provider v4.0.0 breaking changes

### DIFF
--- a/cloud_AWS/terraform/module/examples/all-vpc-from-region/main.tf
+++ b/cloud_AWS/terraform/module/examples/all-vpc-from-region/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
   required_providers {
     aws = {
-      version = ">= 2.28.1"
+      version = ">= 2.28.1, < 4.0.0"
     }
     kentik-cloudexport = {
       version = ">= 0.2.0"

--- a/cloud_AWS/terraform/module/examples/multiple-aws-accounts-multiple-vpc-setup/main.tf
+++ b/cloud_AWS/terraform/module/examples/multiple-aws-accounts-multiple-vpc-setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
   required_providers {
     aws = {
-      version = ">= 2.28.1"
+      version = ">= 2.28.1, < 4.0.0"
     }
     kentik-cloudexport = {
       version = ">= 0.2.0"

--- a/cloud_AWS/terraform/module/examples/no-cloudexport/main.tf
+++ b/cloud_AWS/terraform/module/examples/no-cloudexport/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
   required_providers {
     aws = {
-      version = ">= 2.28.1"
+      version = ">= 2.28.1, < 4.0.0"
     }
     kentik-cloudexport = {
       version = ">= 0.2.0"

--- a/cloud_AWS/terraform/module/examples/single-vpc/main.tf
+++ b/cloud_AWS/terraform/module/examples/single-vpc/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
   required_providers {
     aws = {
-      version = ">= 2.28.1"
+      version = ">= 2.28.1, < 4.0.0"
     }
     kentik-cloudexport = {
       version = ">= 0.2.0"

--- a/cloud_AWS/terraform/module/examples/sock-shop-eks/main.tf
+++ b/cloud_AWS/terraform/module/examples/sock-shop-eks/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = ">= 2.28.1"
+  version = ">= 2.28.1, < 4.0.0"
   region  = var.region
   profile = var.aws_profile
 }

--- a/cloud_AWS/terraform/module/tests/main.tf
+++ b/cloud_AWS/terraform/module/tests/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.12.0"
   required_providers {
     aws = {
-      version = ">= 2.28.1"
+      version = ">= 2.28.1, < 4.0.0"
     }
     kentik-cloudexport = {
       version = ">= 0.2.0"


### PR DESCRIPTION
KNTK-395

- restrict Terraform AWS provider used in configuration to version < 4.0.0. This is temporary solution to unblock other tasks