### PR TITLE
Update Terraform and providers versions in GCP module

### DIFF
--- a/.github/workflows/gcp-terraform.yml
+++ b/.github/workflows/gcp-terraform.yml
@@ -21,10 +21,10 @@ jobs:
       
       # Initialize the Terraform code
       - name: (HELPER) Init Code 
-        uses: docker://hashicorp/terraform:0.14.9
+        uses: docker://hashicorp/terraform:1.0.0
         with:
           entrypoint: terraform
-          args: init cloud_GCP/terraform/module/tests/
+          args: -chdir=cloud_GCP/terraform/module/tests/ init -no-color
        
       # Lint the Terraform code 
       # Using: https://github.com/terraform-linters/tflint
@@ -36,7 +36,7 @@ jobs:
       # Validate the Terraform code using inbuilt
       # validate command
       - name: Validate Module
-        uses: docker://hashicorp/terraform:0.14.9
+        uses: docker://hashicorp/terraform:1.0.0
         with:
           entrypoint: terraform
-          args: validate cloud_GCP/terraform/module/tests/ -no-color
+          args: -chdir=cloud_GCP/terraform/module/tests/ validate -no-color

--- a/cloud_GCP/terraform/module/README.md
+++ b/cloud_GCP/terraform/module/README.md
@@ -66,7 +66,7 @@ module "kentik_gcp_integration" {
 |------|---------|
 | terraform | >=0.12.0 |
 | google provider| >= 4.0.0 |
-| kentik-cloudexport provider| >= 0.1.0 |
+| kentik-cloudexport provider| >= 0.4.0 |
 | null provider | >= 2.1.2 |
 
 ## Inputs

--- a/cloud_GCP/terraform/module/README.md
+++ b/cloud_GCP/terraform/module/README.md
@@ -65,17 +65,9 @@ module "kentik_gcp_integration" {
 | Name | Version |
 |------|---------|
 | terraform | >=0.12.0 |
-| google | >= 3.41.0 |
-| kentik-cloudexport | >= 0.1.0 |
-| null | >= 2.1.2 |
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| google | >= 3.41.0 |
-| kentik-cloudexport | >= 0.1.0 |
-| null | >= 2.1.2 |
+| google provider| >= 4.0.0 |
+| kentik-cloudexport provider| >= 0.1.0 |
+| null provider | >= 2.1.2 |
 
 ## Inputs
 

--- a/cloud_GCP/terraform/module/README.md
+++ b/cloud_GCP/terraform/module/README.md
@@ -64,7 +64,7 @@ module "kentik_gcp_integration" {
 
 | Name | Version |
 |------|---------|
-| terraform | >=0.12.0 |
+| terraform | >= 1.0.0 |
 | google provider| >= 4.0.0 |
 | kentik-cloudexport provider| >= 0.4.0 |
 | null provider | >= 2.1.2 |

--- a/cloud_GCP/terraform/module/cloudexport.tf
+++ b/cloud_GCP/terraform/module/cloudexport.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kentik-cloudexport = {
       source = "kentik/kentik-cloudexport"
-      version = ">= 0.2.0"
+      version = "~> 0.4"
     }
   }
 }

--- a/cloud_GCP/terraform/module/examples/all-network-subnets/main.tf
+++ b/cloud_GCP/terraform/module/examples/all-network-subnets/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = "~> 1.0"
   required_providers {
     google = {
       version = "~> 4.0"

--- a/cloud_GCP/terraform/module/examples/all-network-subnets/main.tf
+++ b/cloud_GCP/terraform/module/examples/all-network-subnets/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
   required_providers {
     google = {
-      version = ">= 3.41.0"
+      version = "~> 4.0"
     }
     kentik-cloudexport = {
       version = ">= 0.2.0"

--- a/cloud_GCP/terraform/module/examples/all-network-subnets/main.tf
+++ b/cloud_GCP/terraform/module/examples/all-network-subnets/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = "~> 4.0"
     }
     kentik-cloudexport = {
-      version = ">= 0.2.0"
+      version = "~> 0.4"
       source = "kentik/kentik-cloudexport"
     }
   }

--- a/cloud_GCP/terraform/module/examples/subnet-list/main.tf
+++ b/cloud_GCP/terraform/module/examples/subnet-list/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = "~> 1.0"
   required_providers {
     google = {
       version = "~> 4.0"

--- a/cloud_GCP/terraform/module/examples/subnet-list/main.tf
+++ b/cloud_GCP/terraform/module/examples/subnet-list/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
   required_providers {
     google = {
-      version = ">= 3.41.0"
+      version = "~> 4.0"
     }
     kentik-cloudexport = {
       version = ">= 0.2.0"

--- a/cloud_GCP/terraform/module/examples/subnet-list/main.tf
+++ b/cloud_GCP/terraform/module/examples/subnet-list/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = "~> 4.0"
     }
     kentik-cloudexport = {
-      version = ">= 0.2.0"
+      version = "~> 0.4"
       source = "kentik/kentik-cloudexport"
     }
   }

--- a/cloud_GCP/terraform/module/tests/main.tf
+++ b/cloud_GCP/terraform/module/tests/main.tf
@@ -1,6 +1,6 @@
 ## Configure GCP provider for tests
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = "~> 1.0"
   required_providers {
     google = {
       version = "~> 4.0"

--- a/cloud_GCP/terraform/module/tests/main.tf
+++ b/cloud_GCP/terraform/module/tests/main.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 4.0"
     }
     kentik-cloudexport = {
-      version = ">= 0.2.0"
+      version = "~> 0.4"
       source = "kentik/kentik-cloudexport"
     }
   }

--- a/cloud_GCP/terraform/module/tests/main.tf
+++ b/cloud_GCP/terraform/module/tests/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.12.0"
   required_providers {
     google = {
-      version = ">= 3.41.0"
+      version = "~> 4.0"
     }
     kentik-cloudexport = {
       version = ">= 0.2.0"


### PR DESCRIPTION
KNTK-397

Update GCP Terraform module:
- use Google provider version >= 4.0.0, < 5.0.0
- use kentik-cloudexport version >=0.4.0, < 1.0.0
- use Terraform version >= 1.0.0, < 2.0.0
