### PR TITLE
Fix/cloudexport aws config create role false

### DIFF
--- a/cloud_AWS/terraform/module/cloudexport.tf
+++ b/cloud_AWS/terraform/module/cloudexport.tf
@@ -21,7 +21,7 @@ resource "kentik-cloudexport_item" "aws_export" {
       for bucketobject in aws_s3_bucket.vpc_logs :
       (var.s3_flowlogs_path == "" ? bucketobject.bucket : "${bucketobject.bucket}/${var.s3_flowlogs_path}")
     ])
-    iam_role_arn      = var.create_role ? aws_iam_role.kentik_role.*.arn[0] : ""
+    iam_role_arn      = var.create_role ? aws_iam_role.kentik_role[0].arn : ""
     region            = var.region
     delete_after_read = var.delete_after_read
     multiple_buckets  = var.multiple_buckets

--- a/cloud_AWS/terraform/module/cloudexport.tf
+++ b/cloud_AWS/terraform/module/cloudexport.tf
@@ -21,7 +21,7 @@ resource "kentik-cloudexport_item" "aws_export" {
       for bucketobject in aws_s3_bucket.vpc_logs :
       (var.s3_flowlogs_path == "" ? bucketobject.bucket : "${bucketobject.bucket}/${var.s3_flowlogs_path}")
     ])
-    iam_role_arn      = aws_iam_role.kentik_role.*.arn[0]
+    iam_role_arn      = var.create_role ? aws_iam_role.kentik_role.*.arn[0] : ""
     region            = var.region
     delete_after_read = var.delete_after_read
     multiple_buckets  = var.multiple_buckets

--- a/cloud_AWS/terraform/module/iam.tf
+++ b/cloud_AWS/terraform/module/iam.tf
@@ -40,13 +40,13 @@ resource "aws_iam_policy" "kentik_s3_policy" {
 resource "aws_iam_policy_attachment" "kentik_s3_access" {
   count      = var.create_role ? 1 : 0
   name       = "${var.iam_role_prefix}-s3-access"
-  roles      = [aws_iam_role.kentik_role[count.index].name]
-  policy_arn = aws_iam_policy.kentik_s3_policy[count.index].arn
+  roles      = [aws_iam_role.kentik_role[0].name]
+  policy_arn = aws_iam_policy.kentik_s3_policy[0].arn
 }
 
 resource "aws_iam_policy_attachment" "kentik_ec2_access" {
   count      = var.create_role ? 1 : 0
   name       = "${var.iam_role_prefix}-ec2-access"
-  roles      = [aws_iam_role.kentik_role[count.index].name]
-  policy_arn = aws_iam_policy.kentik_ec2_access[count.index].arn
+  roles      = [aws_iam_role.kentik_role[0].name]
+  policy_arn = aws_iam_policy.kentik_ec2_access[0].arn
 }


### PR DESCRIPTION
KNTT-335

- fix creating AWS cloudexport config with create_role = false