### PR TITLE
Fix s3 bucket AccessControlListNotSupported error

### DIFF
--- a/cloud_AWS/terraform/module/s3.tf
+++ b/cloud_AWS/terraform/module/s3.tf
@@ -8,6 +8,8 @@ resource "aws_s3_bucket_acl" "acl" {
   count  = (var.s3_use_one_bucket == false ? length(var.vpc_id_list) : 1)
   bucket = aws_s3_bucket.vpc_logs[count.index].id
   acl    = "private"
+  # This `depends_on` is to prevent "AccessControlListNotSupported: The bucket does not allow ACLs."
+  depends_on = [aws_s3_bucket_ownership_controls.ownership]
 }
 
 resource "aws_s3_bucket_policy" "policy" {

--- a/cloud_AWS/terraform/module/s3.tf
+++ b/cloud_AWS/terraform/module/s3.tf
@@ -19,6 +19,14 @@ resource "aws_s3_bucket_policy" "policy" {
   })
 }
 
+resource "aws_s3_bucket_ownership_controls" "ownership" {
+  count  = (var.s3_use_one_bucket == false ? length(var.vpc_id_list) : 1)
+  bucket = aws_s3_bucket.vpc_logs[count.index].id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "vpc_logs" {
   count                   = (var.s3_use_one_bucket == false ? length(var.vpc_id_list) : 1)
   bucket                  = aws_s3_bucket.vpc_logs[count.index].id


### PR DESCRIPTION
Fixes `AccessControlListNotSupported` error on S3 bucket resource

```
╷
│ Error: creating S3 bucket ACL for test-bucket-blahblah-ingest-bucket-flow-logs-default: AccessControlListNotSupported: The bucket does not allow ACLs
│       status code: 400, request id: SGVXBXC3FRD04CAP, host id: vX7nBUMk6eSbbc2eTuuLUY62omsXdvr7+emJ3IlbiLMMyNqxhimTMvYHFpBZHDhbSs+ONAehiOs=
│ 
│   with module.kentik_aws_integration.aws_s3_bucket_acl.acl[0],
│   on .terraform/modules/kentik_aws_integration/cloud_AWS/terraform/module/s3.tf line 7, in resource "aws_s3_bucket_acl" "acl":
│    7: resource "aws_s3_bucket_acl" "acl" {
│ 
```