### PR TITLE
update to use non-deprecated modules and to use python3

### DIFF
--- a/.github/workflows/aws-ansible.yml
+++ b/.github/workflows/aws-ansible.yml
@@ -7,6 +7,7 @@ on:
     paths: 'cloud_AWS/ansible/**'
     branches: [ master ]
   pull_request:
+    paths: 'cloud_AWS/ansible/**'
     branches: [ master ]
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+*_override.tfvars
 
 # Include override files you do wish to add to version control using negated pattern
 #

--- a/cloud_Azure/terraform/module/examples/single_account_multiple_resource_groups/terraform.tfvars
+++ b/cloud_Azure/terraform/module/examples/single_account_multiple_resource_groups/terraform.tfvars
@@ -1,8 +1,8 @@
 # Azure
 subscription_id = ""
 location = ""
-resource_group_names = []
-storage_account_names = []
+resource_group_names = [""]
+storage_account_names = [""]
 
 # Kentik
 email= ""

--- a/cloud_Azure/terraform/module/network_watcher.tf
+++ b/cloud_Azure/terraform/module/network_watcher.tf
@@ -13,7 +13,7 @@ data "azurerm_network_watcher" "network_watcher" {
 #   "ResourceGroupName2" -> "NetworkSercurityGroupId3,NetworkSecurityGroupId4"
 # }
 data "external" "nsg_data_source" {
-  program = ["python", "${path.module}/get_nsg.py"]
+  program = ["python3", "${path.module}/get_nsg.py"]
   query = {
     resource_group_names = join(",", var.resource_group_names)
   }

--- a/cloud_Azure/terraform/module/service_principal.tf
+++ b/cloud_Azure/terraform/module/service_principal.tf
@@ -1,7 +1,7 @@
 data "azuread_client_config" "current" {}
 
 data "azuread_service_principals" "existing_nsg_flow_exporter" {
-  application_ids = [var.flow_exporter_application_id]
+  client_ids = [var.flow_exporter_application_id]
   ignore_missing = true
 }
 
@@ -14,7 +14,7 @@ locals {
 resource "azuread_service_principal" "new_nsg_flow_exporter" {
   count = local.nsg_flow_exporter_already_exists ? 0 : 1
 
-  application_id               = var.flow_exporter_application_id
+  client_id               = var.flow_exporter_application_id
   app_role_assignment_required = false
   owners                       = [data.azuread_client_config.current.object_id]
 


### PR DESCRIPTION
update to use non-deprecated modules and to use python3

also added an override for the tvars so users could create local tvar files with their creds without worrying about them going to the repo